### PR TITLE
Order configuration steps execution

### DIFF
--- a/Cinic-Core.package/Configuration.class/instance/apply.st
+++ b/Cinic-Core.package/Configuration.class/instance/apply.st
@@ -1,3 +1,10 @@
 actions
 apply
-	self steps do: [ :step | self executeStep: step ]
+
+	rootSection allSectionsAndNamesDo: [ :eachSection :eachName |
+		self steps detect: [ :eachStep |
+			eachStep group = eachName
+			 ] ifFound: [ :matchingStep |
+				matchingStep executeWith: eachSection
+			 ]
+		 ]

--- a/Cinic-Core.package/Configuration.class/instance/buildSteps.st
+++ b/Cinic-Core.package/Configuration.class/instance/buildSteps.st
@@ -1,6 +1,4 @@
 private
 buildSteps 
-	^ self pragmas collect: [ :pragma | 
-		(pragma method
-			valueWithReceiver: pragma methodClass instanceSide
-			arguments: {  }) asConfigurationStep ]
+	
+	^ (self imageSteps select: [ :eachStep | (self lookup: eachStep group) notNil ])

--- a/Cinic-Core.package/Configuration.class/instance/executeStep..st
+++ b/Cinic-Core.package/Configuration.class/instance/executeStep..st
@@ -1,7 +1,0 @@
-private
-executeStep: step
-	| section |
-	section := self lookup: step group.
-	section ifNotNil: [ :aSection |
-		aSection do: [ 
-		step executeWith: aSection ]]

--- a/Cinic-Core.package/Configuration.class/instance/imagePragmas.st
+++ b/Cinic-Core.package/Configuration.class/instance/imagePragmas.st
@@ -1,5 +1,5 @@
 private
-pragmas
+imagePragmas
    | collector |
 	collector := PragmaCollector new 
 		filter: [ :pragma |  pragma keyword = #configurationStep ].

--- a/Cinic-Core.package/Configuration.class/instance/imageSteps.st
+++ b/Cinic-Core.package/Configuration.class/instance/imageSteps.st
@@ -1,0 +1,6 @@
+private
+imageSteps 
+	^ self imagePragmas collect: [ :pragma | 
+		(pragma method
+			valueWithReceiver: pragma methodClass instanceSide
+			arguments: {  }) asConfigurationStep ]

--- a/Cinic-Core.package/Configuration.class/instance/lookup..st
+++ b/Cinic-Core.package/Configuration.class/instance/lookup..st
@@ -1,8 +1,4 @@
 sections
 lookup: aString 
-	"Lookup can be improved later. This is for cases where the group
-	defintion of a step and label/nesting in the configuration file 
-	is not the same"
-	"Here we assume that there are only top-level groups having the same
-	name"
-	^ rootSection at: aString
+	
+	^ rootSection lookup: aString 

--- a/Cinic-Core.package/Configuration.class/instance/steps..st
+++ b/Cinic-Core.package/Configuration.class/instance/steps..st
@@ -1,0 +1,6 @@
+test hooks
+steps: aCollectionOfStep
+
+	"for tests purpose only.
+	steps will usually be initialized from image pragmas"
+	steps := aCollectionOfStep 

--- a/Cinic-Core.package/ConfigurationSection.class/instance/allSectionsAndNamesDo..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/allSectionsAndNamesDo..st
@@ -1,0 +1,8 @@
+iterating
+allSectionsAndNamesDo: aBlock
+	"in addition to #sectionsAndNamesDo:, I will also iterate over nested section"
+
+	self sectionsAndNamesDo: [ :eachSection :eachSectionName |
+		aBlock valueWithArguments: { eachSection. eachSectionName }.
+		eachSection allSectionsAndNamesDo: aBlock
+		 ]

--- a/Cinic-Core.package/ConfigurationSection.class/instance/extendedAt..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/extendedAt..st
@@ -1,5 +1,5 @@
 accessing
-extendedAt: key
+extendedAt: key 
 	| extendedKey |
 	"extended key lookup. Keys can be surrounded by [] meaning the value 
 	should be evaluated to get a value"

--- a/Cinic-Core.package/ConfigurationSection.class/instance/lookup..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/lookup..st
@@ -1,0 +1,12 @@
+accessing
+lookup: aPropertyOrSectionName
+	"recursively lookup over nested sections"
+
+	| result |
+	result := self at: aPropertyOrSectionName.
+	result ifNil: [ 
+		self sectionsDo: [ :eachSection | 
+					(eachSection lookup: aPropertyOrSectionName)
+						ifNotNil: [ :aValue | ^ aValue ] ].
+		 ].
+	^ result

--- a/Cinic-Core.package/ConfigurationSection.class/instance/sectionsAndNamesDo..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/sectionsAndNamesDo..st
@@ -1,0 +1,14 @@
+iterating
+sectionsAndNamesDo: aBlock
+	"this method is expected to be performed with a two arguments block .
+	i will iterate over my inner sections. 
+	For each inner section i will execute the passed block with:
+	- the section as first argument
+	- the section name as second argument"
+	| section |
+	self keysDo: [ :eachName |
+		section := (self at: eachName).
+		(section isKindOf: ConfigurationSection) ifTrue: [ 
+			aBlock valueWithArguments: { section. eachName }
+			 ]
+		 ]

--- a/Cinic-Core.package/ConfigurationSection.class/instance/sectionsDo..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/sectionsDo..st
@@ -1,0 +1,6 @@
+iterating
+sectionsDo: aBlock
+
+	self sectionsAndNamesDo: [ :eachSection :eachName |
+		aBlock valueWithArguments: { eachSection }
+		 ]

--- a/Cinic-Core.package/ConfigurationSection.class/properties.json
+++ b/Cinic-Core.package/ConfigurationSection.class/properties.json
@@ -1,6 +1,6 @@
 {
 	"commentStamp" : "NorbertHartl 4/23/2019 16:57",
-	"super" : "Dictionary",
+	"super" : "OrderedDictionary",
 	"category" : "Cinic-Core",
 	"classinstvars" : [ ],
 	"pools" : [ ],

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/configNestedSections.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/configNestedSections.st
@@ -1,0 +1,3 @@
+configurations
+configNestedSections
+	^ Configuration readJSONFrom: self jsonNestedSections readStream

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
@@ -1,0 +1,15 @@
+json
+jsonNestedSections
+	^ '{ 
+	"section1" : { "subkey1" : "subvalue1" },  
+	"section2" : { 
+		"section21" : { 
+			"section211" : { "subkey211" : "subvalue" },
+			"section212" : { "subkey212" : "subvalue" }
+			},
+		"section22" : { "subkey22" : "subvalue" } 
+		},
+	"section3" : { 
+		"section31" : { "subkey31" : "subvalue1" }
+		}
+		}'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
@@ -1,0 +1,22 @@
+tests
+testConfigStepsOrder
+	"check that configuration steps are executed in the same order as the associated section order in the configuration file"
+
+	| config steps executedStepSections |
+	config := self configNestedSections.
+	executedStepSections := OrderedCollection new.
+	steps := #('section1' 'section3'  'section212' 'section2' 'section22' 'section31' 'section21' 'section211') collect: [:eachSectionName |
+		ConfigurationStep new
+			group: eachSectionName;
+			action: [ :c | executedStepSections add: eachSectionName  ]
+		].
+	config steps: steps.
+	config apply.
+	self assert: (executedStepSections at: 1) = 'section1'.
+	self assert: (executedStepSections at: 2) = 'section2'.
+	self assert: (executedStepSections at: 3) = 'section21'.
+	self assert: (executedStepSections at: 4) = 'section211'.
+	self assert: (executedStepSections at: 5) = 'section212'.
+	self assert: (executedStepSections at: 6) = 'section22'.
+	self assert: (executedStepSections at: 7) = 'section3'.
+	self assert: (executedStepSections at: 8) = 'section31'.


### PR DESCRIPTION
made configuration steps execution follow the same order as the sections definition order.

In order to achieve that I made ConfigurationSection being a subclass of OrderedDictionary instead of Dictionary.
Plus implemented some convenience methods
Also refined #lookup: method