### PR TITLE
improve configuration steps mechanism

### DIFF
--- a/Cinic-Core.package/Configuration.class/instance/apply.st
+++ b/Cinic-Core.package/Configuration.class/instance/apply.st
@@ -1,10 +1,11 @@
 actions
 apply
 
-	rootSection allSectionsAndNamesDo: [ :eachSection :eachName |
-		self steps detect: [ :eachStep |
-			eachStep group = eachName
-			 ] ifFound: [ :matchingStep |
-				matchingStep executeWith: eachSection
-			 ]
-		 ]
+	rootSection paths do: [:eachPath |
+		self steps do: [ :eachStep |  
+			(eachStep matchesPath: eachPath) ifTrue: [ 
+				eachStep executeWith: (rootSection atPath: eachPath)
+				 ]
+			]
+		].
+	

--- a/Cinic-Core.package/Configuration.class/instance/buildSteps.st
+++ b/Cinic-Core.package/Configuration.class/instance/buildSteps.st
@@ -1,4 +1,4 @@
 private
 buildSteps 
 	
-	^ (self imageSteps select: [ :eachStep | (self lookup: eachStep group) notNil ])
+	^ self imageSteps

--- a/Cinic-Core.package/Configuration.class/instance/imageSteps.st
+++ b/Cinic-Core.package/Configuration.class/instance/imageSteps.st
@@ -1,6 +1,6 @@
 private
 imageSteps 
-	^ self imagePragmas collect: [ :pragma | 
+	^ (self imagePragmas collect: [ :pragma | 
 		(pragma method
 			valueWithReceiver: pragma methodClass instanceSide
-			arguments: {  }) asConfigurationStep ]
+			arguments: {  }) asConfigurationStep ]) 

--- a/Cinic-Core.package/Configuration.class/instance/steps..st
+++ b/Cinic-Core.package/Configuration.class/instance/steps..st
@@ -3,4 +3,4 @@ steps: aCollectionOfStep
 
 	"for tests purpose only.
 	steps will usually be initialized from image pragmas"
-	steps := aCollectionOfStep 
+	steps := aCollectionOfStep

--- a/Cinic-Core.package/Configuration.class/instance/steps.st
+++ b/Cinic-Core.package/Configuration.class/instance/steps.st
@@ -1,4 +1,4 @@
 accessing
 steps 
 	^ steps ifNil: [ 
-		steps := self buildSteps ]
+		steps :=  self buildSteps ]

--- a/Cinic-Core.package/ConfigurationSection.class/instance/allSectionsAndNamesDo..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/allSectionsAndNamesDo..st
@@ -1,8 +1,0 @@
-iterating
-allSectionsAndNamesDo: aBlock
-	"in addition to #sectionsAndNamesDo:, I will also iterate over nested section"
-
-	self sectionsAndNamesDo: [ :eachSection :eachSectionName |
-		aBlock valueWithArguments: { eachSection. eachSectionName }.
-		eachSection allSectionsAndNamesDo: aBlock
-		 ]

--- a/Cinic-Core.package/ConfigurationSection.class/instance/atPath..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/atPath..st
@@ -1,0 +1,5 @@
+accessing
+atPath: aCollectionOfKeys 
+	
+	^self atPath: aCollectionOfKeys ifAbsent: [KeyNotFound signalFor: aCollectionOfKeys]
+	

--- a/Cinic-Core.package/ConfigurationSection.class/instance/atPath.ifAbsent..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/atPath.ifAbsent..st
@@ -4,7 +4,7 @@ atPath: aCollectionOfKeys ifAbsent: aBlock
 	| section |
 	section := self.
 	aCollectionOfKeys do: [ :eachKey |
-		(section isKindOf: ConfigurationSection) ifFalse: [ ^ aBlock value ].
+		section isDictionary ifFalse: [ ^ aBlock value ].
 		section := (section at: eachKey).
 		 ].
 	^ section

--- a/Cinic-Core.package/ConfigurationSection.class/instance/atPath.ifAbsent..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/atPath.ifAbsent..st
@@ -1,0 +1,11 @@
+accessing
+atPath: aCollectionOfKeys ifAbsent: aBlock
+
+	| section |
+	section := self.
+	aCollectionOfKeys do: [ :eachKey |
+		(section isKindOf: ConfigurationSection) ifFalse: [ ^ aBlock value ].
+		section := (section at: eachKey).
+		 ].
+	^ section
+	

--- a/Cinic-Core.package/ConfigurationSection.class/instance/paths.st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/paths.st
@@ -1,0 +1,4 @@
+accessing
+paths
+
+	^ self pathsFrom: #()

--- a/Cinic-Core.package/ConfigurationSection.class/instance/pathsFrom..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/pathsFrom..st
@@ -1,0 +1,12 @@
+accessing
+pathsFrom: parentPath
+
+	| result path |
+	result := OrderedCollection new.
+	self keysAndValuesDo: [ :eachKey :eachValue |
+		path := OrderedCollection new addAll: parentPath; add: eachKey; yourself.
+		result add: path.
+		eachValue isDictionary  ifTrue: [
+			result addAll: (eachValue pathsFrom: path)].
+		 ].
+	^ result

--- a/Cinic-Core.package/ConfigurationStep.class/instance/group..st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/group..st
@@ -1,3 +1,0 @@
-accessing
-group: aString 
-	group := aString

--- a/Cinic-Core.package/ConfigurationStep.class/instance/group.st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/group.st
@@ -1,3 +1,0 @@
-accessing
-group
-	^ group

--- a/Cinic-Core.package/ConfigurationStep.class/instance/matchesPath..st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/matchesPath..st
@@ -1,0 +1,4 @@
+executing
+matchesPath: aCollectionOfKeys
+
+	^ self sectionPath hasEqualElements: aCollectionOfKeys

--- a/Cinic-Core.package/ConfigurationStep.class/instance/matchesPath..st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/matchesPath..st
@@ -1,4 +1,4 @@
 executing
 matchesPath: aCollectionOfKeys
 
-	^ self sectionPath hasEqualElements: aCollectionOfKeys
+	^ aCollectionOfKeys endsWith: self sectionPath

--- a/Cinic-Core.package/ConfigurationStep.class/instance/section..st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/section..st
@@ -1,0 +1,4 @@
+accessing
+section: aSymbol
+
+	self sectionPath:  {aSymbol}

--- a/Cinic-Core.package/ConfigurationStep.class/instance/sectionPath..st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/sectionPath..st
@@ -1,0 +1,4 @@
+accessing
+sectionPath: aCollectionOfSymbols
+
+	sectionPath := aCollectionOfSymbols 

--- a/Cinic-Core.package/ConfigurationStep.class/instance/sectionPath.st
+++ b/Cinic-Core.package/ConfigurationStep.class/instance/sectionPath.st
@@ -1,0 +1,5 @@
+accessing
+sectionPath
+	"answers a collection os symbols.
+	represent the path to the associated section for which this step should be executed"
+	^ sectionPath 

--- a/Cinic-Core.package/ConfigurationStep.class/properties.json
+++ b/Cinic-Core.package/ConfigurationStep.class/properties.json
@@ -6,8 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"group",
-		"action"
+		"action",
+		"sectionPath"
 	],
 	"name" : "ConfigurationStep",
 	"type" : "normal"

--- a/Cinic-Core.package/ConfiguratorTests.class/class/subSectionStep.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/class/subSectionStep.st
@@ -2,5 +2,5 @@ resources
 subSectionStep
 	<configurationStep>
 	^ ConfigurationStep new
-		group: self subSectionName;
+		section: self subSectionName;
 		action: [ :config | self appliedConfigs at: self subSectionName put: config  ]

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/configNestedSectionsMultipleMatch.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/configNestedSectionsMultipleMatch.st
@@ -1,0 +1,3 @@
+configurations
+configNestedSectionsMultipleMatch
+	^ Configuration readJSONFrom: self jsonNestedSectionsMultipleMatch readStream

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
@@ -1,15 +1,15 @@
 json
 jsonNestedSections
 	^ '{ 
-	"1" : { "subkey1" : "subvalue1" },  
-	"2" : { 
-		"1" : { 
+	"A" : { "subkey1" : "subvalue1" },  
+	"B" : { 
+		"a" : { 
 			"1" : { "subkey211" : "subvalue" },
 			"2" : { "subkey212" : "subvalue" }
 			},
-		"2" : { "subkey22" : "subvalue" } 
+		"b" : { "subkey22" : "subvalue" } 
 		},
-	"3" : { 
-		"1" : { "subkey31" : "subvalue1" }
+	"C" : { 
+		"a" : { "subkey31" : "subvalue1" }
 		}
 		}'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSections.st
@@ -1,15 +1,15 @@
 json
 jsonNestedSections
 	^ '{ 
-	"section1" : { "subkey1" : "subvalue1" },  
-	"section2" : { 
-		"section21" : { 
-			"section211" : { "subkey211" : "subvalue" },
-			"section212" : { "subkey212" : "subvalue" }
+	"1" : { "subkey1" : "subvalue1" },  
+	"2" : { 
+		"1" : { 
+			"1" : { "subkey211" : "subvalue" },
+			"2" : { "subkey212" : "subvalue" }
 			},
-		"section22" : { "subkey22" : "subvalue" } 
+		"2" : { "subkey22" : "subvalue" } 
 		},
-	"section3" : { 
-		"section31" : { "subkey31" : "subvalue1" }
+	"3" : { 
+		"1" : { "subkey31" : "subvalue1" }
 		}
 		}'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSectionsMultipleMatch.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonNestedSectionsMultipleMatch.st
@@ -1,0 +1,15 @@
+json
+jsonNestedSectionsMultipleMatch
+	^ '{ 
+	"1" : { "subkey1" : "subvalue1" },  
+	"2" : { 
+		"1" : { 
+			"1" : { "subkey211" : "subvalue" },
+			"2" : { "subkey212" : "subvalue" }
+			},
+		"2" : { "subkey22" : "subvalue" } 
+		},
+	"3" : { 
+		"1" : { "subkey31" : "subvalue1" }
+		}
+		}'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
@@ -5,18 +5,18 @@ testConfigStepsOrder
 	| config steps executedStepSections |
 	config := self configNestedSections.
 	executedStepSections := OrderedCollection new.
-	steps := #('section1' 'section3'  'section212' 'section2' 'section22' 'section31' 'section21' 'section211') collect: [:eachSectionName |
+	steps := #('1' '3'  '212' '2' '22' '31' '21' '211') collect: [:eachSectionName |
 		ConfigurationStep new
-			group: eachSectionName;
+			sectionPath: (eachSectionName asOrderedCollection collect: #asString);
 			action: [ :c | executedStepSections add: eachSectionName  ]
 		].
 	config steps: steps.
 	config apply.
-	self assert: (executedStepSections at: 1) = 'section1'.
-	self assert: (executedStepSections at: 2) = 'section2'.
-	self assert: (executedStepSections at: 3) = 'section21'.
-	self assert: (executedStepSections at: 4) = 'section211'.
-	self assert: (executedStepSections at: 5) = 'section212'.
-	self assert: (executedStepSections at: 6) = 'section22'.
-	self assert: (executedStepSections at: 7) = 'section3'.
-	self assert: (executedStepSections at: 8) = 'section31'.
+	self assert: (executedStepSections at: 1) = '1'.
+	self assert: (executedStepSections at: 2) = '2'.
+	self assert: (executedStepSections at: 3) = '21'.
+	self assert: (executedStepSections at: 4) = '211'.
+	self assert: (executedStepSections at: 5) = '212'.
+	self assert: (executedStepSections at: 6) = '22'.
+	self assert: (executedStepSections at: 7) = '3'.
+	self assert: (executedStepSections at: 8) = '31'.

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrder.st
@@ -5,18 +5,18 @@ testConfigStepsOrder
 	| config steps executedStepSections |
 	config := self configNestedSections.
 	executedStepSections := OrderedCollection new.
-	steps := #('1' '3'  '212' '2' '22' '31' '21' '211') collect: [:eachSectionName |
+	steps := #('A' 'C'  'Ba2' 'B' 'Bb' 'Ca' 'Ba' 'Ba1') collect: [:eachSectionName |
 		ConfigurationStep new
 			sectionPath: (eachSectionName asOrderedCollection collect: #asString);
 			action: [ :c | executedStepSections add: eachSectionName  ]
 		].
 	config steps: steps.
 	config apply.
-	self assert: (executedStepSections at: 1) = '1'.
-	self assert: (executedStepSections at: 2) = '2'.
-	self assert: (executedStepSections at: 3) = '21'.
-	self assert: (executedStepSections at: 4) = '211'.
-	self assert: (executedStepSections at: 5) = '212'.
-	self assert: (executedStepSections at: 6) = '22'.
-	self assert: (executedStepSections at: 7) = '3'.
-	self assert: (executedStepSections at: 8) = '31'.
+	self assert: (executedStepSections at: 1) = 'A'.
+	self assert: (executedStepSections at: 2) = 'B'.
+	self assert: (executedStepSections at: 3) = 'Ba'.
+	self assert: (executedStepSections at: 4) = 'Ba1'.
+	self assert: (executedStepSections at: 5) = 'Ba2'.
+	self assert: (executedStepSections at: 6) = 'Bb'.
+	self assert: (executedStepSections at: 7) = 'C'.
+	self assert: (executedStepSections at: 8) = 'Ca'.

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrderWithMultipleMatches.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsOrderWithMultipleMatches.st
@@ -1,0 +1,42 @@
+tests
+testConfigStepsOrderWithMultipleMatches
+	"check that configuration a given step matches several sections from a configuration file, it gets executed several times.
+	Example:
+	
+	section a {
+		section a { 
+		...
+		 }
+	  }
+	
+	a step defined with sectionPath #(a) will match both paths: #(a) and #(a a)
+	"
+
+	| config steps executedStepSections |
+	config := self configNestedSectionsMultipleMatch .
+	executedStepSections := OrderedCollection new.
+	steps := #('1' '3'  '212' '2' '22' '31' '21' '211') collect: [:eachSectionName |
+		ConfigurationStep new
+			sectionPath: (eachSectionName asOrderedCollection collect: #asString);
+			action: [ :c | executedStepSections add: eachSectionName  ]
+		].
+	config steps: steps.
+	config apply.
+	self assert: (executedStepSections at: 1) = '1'.
+	self assert: (executedStepSections at: 2) = '2'.
+	"the step pointing to #(1) will also match path #(2 1): "
+	self assert: (executedStepSections at: 3) = '1'.
+	self assert: (executedStepSections at: 4) = '21'.
+	"the step pointing to #(1) will also match path #(2 1 1): "
+	self assert: (executedStepSections at: 5) = '1'.
+	self assert: (executedStepSections at: 6) = '211'.
+	self assert: (executedStepSections at: 7) = '212'.
+	"the step pointing to #(2) will also match path #(2 1 2): "
+	self assert: (executedStepSections at: 8) = '2'.
+	"the step pointing to #(2) will also match path #(2): "
+	self assert: (executedStepSections at: 9) = '2'.
+	self assert: (executedStepSections at: 10) = '22'.
+	self assert: (executedStepSections at: 11) = '3'.
+	"the step pointing to #(1) will also match path #(3 1): "
+	self assert: (executedStepSections at: 12) = '1'.
+	self assert: (executedStepSections at: 13) = '31'.

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testDictionaryAsConfigurationStep.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testDictionaryAsConfigurationStep.st
@@ -1,7 +1,7 @@
 tests
 testDictionaryAsConfigurationStep
 	| dict step value |
-	dict := { #group -> #def . #action -> [:c| value := c tree key1 ] }.
+	dict := { #section -> #def . #action -> [:c| value := c tree key1 ] }.
 	self 
 		shouldnt: [ step := dict asConfigurationStep  ] 
 		raise: Error.


### PR DESCRIPTION
make configuration steps work with "section path" instead of a unique "section name".

this allows to have several sections with same names within a configuration,
but with different parent section paths.
Also made possible to have several steps pointing to the same section path