### PR TITLE
action value for each section

### DIFF
--- a/Cinic-Core.package/ConfigurationSection.class/instance/actionValue..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/actionValue..st
@@ -1,0 +1,3 @@
+accessing
+actionValue: anObject
+	actionValue := anObject

--- a/Cinic-Core.package/ConfigurationSection.class/instance/actionValue.st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/actionValue.st
@@ -1,0 +1,3 @@
+accessing
+actionValue
+	^ actionValue

--- a/Cinic-Core.package/ConfigurationSection.class/instance/actionValueAtPath..st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/actionValueAtPath..st
@@ -1,0 +1,3 @@
+accessing
+actionValueAtPath: aPath
+	^ (self root atPath: aPath) actionValue

--- a/Cinic-Core.package/ConfigurationSection.class/instance/actionValues.st
+++ b/Cinic-Core.package/ConfigurationSection.class/instance/actionValues.st
@@ -1,0 +1,7 @@
+accessing
+actionValues
+	| actionValues |
+	actionValues := OrderedDictionary new.
+ 	self sectionsAndNamesDo: [ :section :name | 
+		actionValues at: name put: (section actionValue) ].
+	^ actionValues

--- a/Cinic-Core.package/ConfigurationSection.class/properties.json
+++ b/Cinic-Core.package/ConfigurationSection.class/properties.json
@@ -6,7 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"parent"
+		"parent",
+		"actionValue"
 	],
 	"name" : "ConfigurationSection",
 	"type" : "normal"

--- a/Cinic-Core.package/ConfiguratorTests.class/class/subSectionDependsOnSharedValueStep.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/class/subSectionDependsOnSharedValueStep.st
@@ -1,0 +1,7 @@
+resources
+subSectionDependsOnSharedValueStep
+	<configurationStep>
+	^ ConfigurationStep new
+		section: 'dependsOnSharedActionValueSection';
+		action: [ :config |
+			config actionValue: 'it is really ', (config actionValueAtPath: {'sharingActionValueSection'}) ]

--- a/Cinic-Core.package/ConfiguratorTests.class/class/subSectionSharingValueStep.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/class/subSectionSharingValueStep.st
@@ -1,0 +1,7 @@
+resources
+subSectionSharingValueStep
+	<configurationStep>
+	^ ConfigurationStep new
+		section: 'sharingActionValueSection';
+		action: [ :config | 
+			config actionValue: 'an important ', (config at: #key1)	 ]

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/configSectionsMultipleMatch.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/configSectionsMultipleMatch.st
@@ -1,0 +1,3 @@
+configurations
+configSectionsMultipleMatch
+	^ Configuration readJSONFrom: self jsonSectionsMultipleMatch readStream

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/configSectionsSharedActionValues.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/configSectionsSharedActionValues.st
@@ -1,0 +1,3 @@
+configurations
+configSectionsSharedActionValues
+	^ Configuration readJSONFrom: self jsonSectionsSharedActionValues readStream

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonSectionsMultipleMatch.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonSectionsMultipleMatch.st
@@ -1,0 +1,6 @@
+json
+jsonSectionsMultipleMatch
+	^ '{ 
+	"1" : { "subkey1" : "subvalue1" },  
+	"2" : { "subkey2" : "subvalue2" }, 
+	"2" : { "subkey3" : "subvalue3" } }'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/jsonSectionsSharedActionValues.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/jsonSectionsSharedActionValues.st
@@ -1,0 +1,5 @@
+json
+jsonSectionsSharedActionValues
+	^ '{ 
+	"sharingActionValueSection" : { "key1" : "a string" },  
+	"dependsOnSharedActionValueSection" : { "key2" : "nothingImportant" } }'

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigRootStepsOrderWithMultipleMatches.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigRootStepsOrderWithMultipleMatches.st
@@ -1,0 +1,24 @@
+tests
+testConfigRootStepsOrderWithMultipleMatches
+	"check that several same sections at root from a configuration file, do not get executed several times.
+	Example:
+	
+	section 1 { ... }
+	section 2 { ... }
+	section 2 { ... }
+	"
+
+	| config steps executedStepSections |
+	config := self configSectionsMultipleMatch.
+	self assert: config tree keys size equals: 2.
+	executedStepSections := OrderedCollection new.
+	steps := config tree keys collect: [:eachSectionName |
+		ConfigurationStep new
+			sectionPath: (eachSectionName asOrderedCollection collect: #asString);
+			action: [ :c | executedStepSections add: eachSectionName  ]
+		].
+	config steps: steps.
+	config apply.
+	self assert: (executedStepSections at: 1) = '1'.
+	self assert: (executedStepSections at: 2) = '2'.
+	self should: [ executedStepSections at: 3 ] raise: SubscriptOutOfBounds.

--- a/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsSharedActionValues.st
+++ b/Cinic-Core.package/ConfiguratorTests.class/instance/testConfigStepsSharedActionValues.st
@@ -1,0 +1,8 @@
+tests
+testConfigStepsSharedActionValues
+	| config actionValues |
+	config := self configSectionsSharedActionValues.
+	config apply.
+	actionValues := config tree actionValues.
+	self assert: actionValues size equals: 2.
+	self assert: (actionValues at: 'dependsOnSharedActionValueSection') equals: 'it is really an important a string'


### PR DESCRIPTION
As to get used to Cinic and get into it (understand better Cyrille's PR), I decided to add a "feature" after we talked about it last time with Cyrille, that could be useful in the case of Airbus.

I think there are other solution to this so maybe we don't need to add that at all to Cinic. 

I added actionValue to the section so steps can retrieve previously executed steps results referring to a section.

you could do the same just by subclassing the section... but maybe it's nice i don't know